### PR TITLE
Fix UI overlap and replace SVG icons with Lucide components

### DIFF
--- a/src/components/PremiumContentStrategy.tsx
+++ b/src/components/PremiumContentStrategy.tsx
@@ -3810,7 +3810,7 @@ export const PremiumContentStrategy: React.FC<PremiumContentStrategyProps> = ({
   const handleGenerateStrategy = () => {
     console.log("��� Generate Strategy button clicked!");
     console.log("📊 Current strategy config:", strategyConfig);
-    console.log("��� Is loading:", isLoading);
+    console.log("����� Is loading:", isLoading);
     console.log("✅ Niche filled:", !!strategyConfig.niche);
     console.log("✅ Target audience filled:", !!strategyConfig.targetAudience);
     console.log("🎯 Calling onGenerateStrategy with config...");
@@ -4773,7 +4773,7 @@ export const PremiumContentStrategy: React.FC<PremiumContentStrategyProps> = ({
                       Premium
                     </Badge>
                   )}
-                  <Badge variant={isLoading ? 'warning' : strategyPlan ? 'success' : 'neutral'}>
+                  <Badge variant={isLoading ? 'warning' : strategyPlan ? 'success' : 'neutral'} className={isLoading ? 'mt-4' : ''}>
                     {isLoading ? 'Creating...' : strategyPlan ? 'Ready' : 'Configure'}
                   </Badge>
                 </div>

--- a/src/components/PremiumContentStrategy.tsx
+++ b/src/components/PremiumContentStrategy.tsx
@@ -9414,9 +9414,15 @@ export const PremiumContentStrategy: React.FC<PremiumContentStrategyProps> = ({
                           <p className="text-slate-400 text-sm">
                             Choose how to send your strategy to canvas:
                           </p>
-                          <p className="text-slate-400 text-xs mt-1">
-                            📄 <strong>Text:</strong> Complete strategy as formatted text ����
-                            🧠 <strong>Mind Map:</strong> Visual mind map with niche, pillars & keywords
+                          <p className="text-slate-400 text-xs mt-1 flex items-center justify-center gap-4">
+                            <span className="flex items-center gap-1">
+                              <Send className="w-3 h-3" />
+                              <strong>Text:</strong> Complete strategy as formatted text
+                            </span>
+                            <span className="flex items-center gap-1">
+                              <GitBranch className="w-3 h-3" />
+                              <strong>Mind Map:</strong> Visual mind map with niche, pillars & keywords
+                            </span>
                           </p>
                         </div>
                       </div>

--- a/src/components/PremiumContentStrategy.tsx
+++ b/src/components/PremiumContentStrategy.tsx
@@ -65,6 +65,7 @@ import {
   Brain,
   Settings,
   ArrowDown,
+  ChevronRight,
   Send,
   GitBranch,
   Clipboard
@@ -980,7 +981,7 @@ export const PremiumContentStrategy: React.FC<PremiumContentStrategyProps> = ({
 
       // Deduct credit first
       await deductCredits('regenerate', 1);
-      console.log('�������� Credit deducted for advanced metric regeneration');
+      console.log('��������� Credit deducted for advanced metric regeneration');
 
       const strategyConfig = {
         niche: strategyPlan.niche || 'General',
@@ -10377,7 +10378,7 @@ export const PremiumContentStrategy: React.FC<PremiumContentStrategyProps> = ({
                     }}
                     className="px-3 py-1 bg-slate-700 hover:bg-slate-600 text-slate-300 text-xs rounded transition-colors"
                   >
-                    ������� Refresh
+                    �������� Refresh
                   </button>
                 </div>
                 <div className="overflow-x-auto">

--- a/src/components/PremiumContentStrategy.tsx
+++ b/src/components/PremiumContentStrategy.tsx
@@ -6387,9 +6387,7 @@ export const PremiumContentStrategy: React.FC<PremiumContentStrategyProps> = ({
                                                   <div className="absolute inset-0 bg-gradient-to-r from-slate-600/5 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
                                                   <div className="relative flex items-center space-x-4 px-4 py-3.5">
                                                     <div className="w-10 h-10 bg-gradient-to-br from-slate-600/20 to-slate-700/20 rounded-xl flex items-center justify-center group-hover:scale-110 transition-transform duration-300">
-                                                      <svg className="w-5 h-5 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
-                                                      </svg>
+                                                      <Clipboard className="w-5 h-5 text-slate-400" />
                                                     </div>
                                                     <div className="flex-1 text-left">
                                                       <div className="font-semibold text-white text-sm group-hover:text-slate-200 transition-colors">Copy Text</div>
@@ -6562,9 +6560,7 @@ export const PremiumContentStrategy: React.FC<PremiumContentStrategyProps> = ({
                                                     <div className="absolute inset-0 bg-gradient-to-r from-slate-600/5 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
                                                     <div className="relative flex items-center space-x-4 px-4 py-3.5">
                                                       <div className="w-10 h-10 bg-gradient-to-br from-slate-600/20 to-slate-700/20 rounded-xl flex items-center justify-center group-hover:scale-110 transition-transform duration-300">
-                                                        <svg className="w-5 h-5 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
-                                                        </svg>
+                                                        <Clipboard className="w-5 h-5 text-slate-400" />
                                                       </div>
                                                       <div className="flex-1 text-left">
                                                         <div className="font-semibold text-white text-sm group-hover:text-slate-200 transition-colors">Copy Text</div>
@@ -7630,9 +7626,7 @@ export const PremiumContentStrategy: React.FC<PremiumContentStrategyProps> = ({
                                             <div className="absolute inset-0 bg-gradient-to-r from-slate-600/5 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
                                             <div className="relative flex items-center space-x-4 px-4 py-3.5">
                                               <div className="w-10 h-10 bg-gradient-to-br from-slate-600/20 to-slate-700/20 rounded-xl flex items-center justify-center group-hover:scale-110 transition-transform duration-300">
-                                                <svg className="w-5 h-5 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
-                                                </svg>
+                                                <Clipboard className="w-5 h-5 text-slate-400" />
                                               </div>
                                               <div className="flex-1 text-left">
                                                 <div className="font-semibold text-white text-sm group-hover:text-slate-200 transition-colors">Copy Text</div>
@@ -7831,9 +7825,7 @@ export const PremiumContentStrategy: React.FC<PremiumContentStrategyProps> = ({
                                             <div className="absolute inset-0 bg-gradient-to-r from-slate-600/5 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
                                             <div className="relative flex items-center space-x-4 px-4 py-3.5">
                                               <div className="w-10 h-10 bg-gradient-to-br from-slate-600/20 to-slate-700/20 rounded-xl flex items-center justify-center group-hover:scale-110 transition-transform duration-300">
-                                                <svg className="w-5 h-5 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
-                                                </svg>
+                                                <Clipboard className="w-5 h-5 text-slate-400" />
                                               </div>
                                               <div className="flex-1 text-left">
                                                 <div className="font-semibold text-white text-sm group-hover:text-slate-200 transition-colors">Copy Text</div>
@@ -8231,9 +8223,7 @@ export const PremiumContentStrategy: React.FC<PremiumContentStrategyProps> = ({
                                             <div className="absolute inset-0 bg-gradient-to-r from-slate-600/5 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
                                             <div className="relative flex items-center space-x-4 px-4 py-3.5">
                                               <div className="w-10 h-10 bg-gradient-to-br from-slate-600/20 to-slate-700/20 rounded-xl flex items-center justify-center group-hover:scale-110 transition-transform duration-300">
-                                                <svg className="w-5 h-5 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
-                                                </svg>
+                                                <Clipboard className="w-5 h-5 text-slate-400" />
                                               </div>
                                               <div className="flex-1 text-left">
                                                 <div className="font-semibold text-white text-sm group-hover:text-slate-200 transition-colors">Copy Text</div>

--- a/src/components/PremiumContentStrategy.tsx
+++ b/src/components/PremiumContentStrategy.tsx
@@ -3810,7 +3810,7 @@ export const PremiumContentStrategy: React.FC<PremiumContentStrategyProps> = ({
   const handleGenerateStrategy = () => {
     console.log("��� Generate Strategy button clicked!");
     console.log("📊 Current strategy config:", strategyConfig);
-    console.log("����� Is loading:", isLoading);
+    console.log("��� Is loading:", isLoading);
     console.log("✅ Niche filled:", !!strategyConfig.niche);
     console.log("✅ Target audience filled:", !!strategyConfig.targetAudience);
     console.log("🎯 Calling onGenerateStrategy with config...");
@@ -4766,14 +4766,14 @@ export const PremiumContentStrategy: React.FC<PremiumContentStrategyProps> = ({
               icon={<CompassIcon />}
               badge={isPremium ? "Premium" : "Free"}
               actions={
-                <div className="flex items-center space-x-3">
+                <div className="flex items-center space-x-3 mt-8">
                   {isPremium && (
                     <Badge variant="primary">
                       <CrownIcon className="w-3 h-3" />
                       Premium
                     </Badge>
                   )}
-                  <Badge variant={isLoading ? 'warning' : strategyPlan ? 'success' : 'neutral'} className={isLoading ? 'mt-4' : ''}>
+                  <Badge variant={isLoading ? 'warning' : strategyPlan ? 'success' : 'neutral'}>
                     {isLoading ? 'Creating...' : strategyPlan ? 'Ready' : 'Configure'}
                   </Badge>
                 </div>

--- a/src/components/PremiumContentStrategy.tsx
+++ b/src/components/PremiumContentStrategy.tsx
@@ -6747,9 +6747,7 @@ export const PremiumContentStrategy: React.FC<PremiumContentStrategyProps> = ({
                                                       <div className="absolute inset-0 bg-gradient-to-r from-slate-600/5 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
                                                       <div className="relative flex items-center space-x-4 px-4 py-3.5">
                                                         <div className="w-10 h-10 bg-gradient-to-br from-slate-600/20 to-slate-700/20 rounded-xl flex items-center justify-center group-hover:scale-110 transition-transform duration-300">
-                                                          <svg className="w-5 h-5 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
-                                                          </svg>
+                                                          <Clipboard className="w-5 h-5 text-slate-400" />
                                                         </div>
                                                         <div className="flex-1 text-left">
                                                           <div className="font-semibold text-white text-sm group-hover:text-slate-200 transition-colors">Copy Text</div>
@@ -6877,9 +6875,7 @@ export const PremiumContentStrategy: React.FC<PremiumContentStrategyProps> = ({
                                                       <div className="absolute inset-0 bg-gradient-to-r from-slate-600/5 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
                                                       <div className="relative flex items-center space-x-4 px-4 py-3.5">
                                                         <div className="w-10 h-10 bg-gradient-to-br from-slate-600/20 to-slate-700/20 rounded-xl flex items-center justify-center group-hover:scale-110 transition-transform duration-300">
-                                                          <svg className="w-5 h-5 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
-                                                          </svg>
+                                                          <Clipboard className="w-5 h-5 text-slate-400" />
                                                         </div>
                                                         <div className="flex-1 text-left">
                                                           <div className="font-semibold text-white text-sm group-hover:text-slate-200 transition-colors">Copy Text</div>
@@ -7007,9 +7003,7 @@ export const PremiumContentStrategy: React.FC<PremiumContentStrategyProps> = ({
                                                       <div className="absolute inset-0 bg-gradient-to-r from-slate-600/5 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
                                                       <div className="relative flex items-center space-x-4 px-4 py-3.5">
                                                         <div className="w-10 h-10 bg-gradient-to-br from-slate-600/20 to-slate-700/20 rounded-xl flex items-center justify-center group-hover:scale-110 transition-transform duration-300">
-                                                          <svg className="w-5 h-5 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
-                                                          </svg>
+                                                          <Clipboard className="w-5 h-5 text-slate-400" />
                                                         </div>
                                                         <div className="flex-1 text-left">
                                                           <div className="font-semibold text-white text-sm group-hover:text-slate-200 transition-colors">Copy Text</div>
@@ -7137,9 +7131,7 @@ export const PremiumContentStrategy: React.FC<PremiumContentStrategyProps> = ({
                                                       <div className="absolute inset-0 bg-gradient-to-r from-slate-600/5 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
                                                       <div className="relative flex items-center space-x-4 px-4 py-3.5">
                                                         <div className="w-10 h-10 bg-gradient-to-br from-slate-600/20 to-slate-700/20 rounded-xl flex items-center justify-center group-hover:scale-110 transition-transform duration-300">
-                                                          <svg className="w-5 h-5 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
-                                                          </svg>
+                                                          <Clipboard className="w-5 h-5 text-slate-400" />
                                                         </div>
                                                         <div className="flex-1 text-left">
                                                           <div className="font-semibold text-white text-sm group-hover:text-slate-200 transition-colors">Copy Text</div>
@@ -7385,9 +7377,7 @@ export const PremiumContentStrategy: React.FC<PremiumContentStrategyProps> = ({
                                                       <div className="absolute inset-0 bg-gradient-to-r from-slate-600/5 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
                                                       <div className="relative flex items-center space-x-4 px-4 py-3.5">
                                                         <div className="w-10 h-10 bg-gradient-to-br from-slate-600/20 to-slate-700/20 rounded-xl flex items-center justify-center group-hover:scale-110 transition-transform duration-300">
-                                                          <svg className="w-5 h-5 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
-                                                          </svg>
+                                                          <Clipboard className="w-5 h-5 text-slate-400" />
                                                         </div>
                                                         <div className="flex-1 text-left">
                                                           <div className="font-semibold text-white text-sm group-hover:text-slate-200 transition-colors">Copy Text</div>

--- a/src/components/PremiumContentStrategy.tsx
+++ b/src/components/PremiumContentStrategy.tsx
@@ -64,7 +64,10 @@ import {
   Lock,
   Brain,
   Settings,
-  ArrowDown
+  ArrowDown,
+  Send,
+  GitBranch,
+  Clipboard
 } from "lucide-react";
 
 // Import our world-class design system components
@@ -9430,7 +9433,7 @@ export const PremiumContentStrategy: React.FC<PremiumContentStrategyProps> = ({
                             onClick={sendEntireStrategyToCanvas}
                             className="px-6 py-3 bg-gradient-to-r from-emerald-600 to-blue-600 hover:from-emerald-500 hover:to-blue-500 text-white rounded-xl text-lg font-semibold transition-all duration-200 flex items-center space-x-3 shadow-lg hover:shadow-xl"
                           >
-                            <FileText className="w-5 h-5" />
+                            <Send className="w-5 h-5" />
                             <span>Send as Text</span>
                           </button>
 
@@ -9439,9 +9442,9 @@ export const PremiumContentStrategy: React.FC<PremiumContentStrategyProps> = ({
                               onClick={sendStrategyAsMindMap}
                               className="px-6 py-3 bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-500 hover:to-pink-500 text-white rounded-xl text-lg font-semibold transition-all duration-200 flex items-center space-x-3 shadow-lg hover:shadow-xl"
                             >
-                              <Network className="w-5 h-5" />
+                              <GitBranch className="w-5 h-5" />
                               <span>Send as Mind Map</span>
-                              <Sparkles className="w-5 h-5" />
+                              <Brain className="w-5 h-5" />
                             </button>
                           )}
                         </div>

--- a/src/components/PremiumContentStrategy.tsx
+++ b/src/components/PremiumContentStrategy.tsx
@@ -981,7 +981,7 @@ export const PremiumContentStrategy: React.FC<PremiumContentStrategyProps> = ({
 
       // Deduct credit first
       await deductCredits('regenerate', 1);
-      console.log('��������� Credit deducted for advanced metric regeneration');
+      console.log('�������� Credit deducted for advanced metric regeneration');
 
       const strategyConfig = {
         niche: strategyPlan.niche || 'General',
@@ -6394,9 +6394,7 @@ export const PremiumContentStrategy: React.FC<PremiumContentStrategyProps> = ({
                                                       <div className="font-semibold text-white text-sm group-hover:text-slate-200 transition-colors">Copy Text</div>
                                                       <div className="text-xs text-slate-400 group-hover:text-slate-300/80 transition-colors">Copy to clipboard</div>
                                                     </div>
-                                                    <svg className="w-4 h-4 text-slate-500 group-hover:text-slate-400 group-hover:translate-x-1 transition-all duration-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-                                                    </svg>
+                                                    <ChevronRight className="w-4 h-4 text-slate-500 group-hover:text-slate-400 group-hover:translate-x-1 transition-all duration-300" />
                                                   </div>
                                                 </button>
                                               </div>
@@ -6567,9 +6565,7 @@ export const PremiumContentStrategy: React.FC<PremiumContentStrategyProps> = ({
                                                         <div className="font-semibold text-white text-sm group-hover:text-slate-200 transition-colors">Copy Text</div>
                                                         <div className="text-xs text-slate-400 group-hover:text-slate-300/80 transition-colors">Copy to clipboard</div>
                                                       </div>
-                                                      <svg className="w-4 h-4 text-slate-500 group-hover:text-slate-400 group-hover:translate-x-1 transition-all duration-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-                                                      </svg>
+                                                      <ChevronRight className="w-4 h-4 text-slate-500 group-hover:text-slate-400 group-hover:translate-x-1 transition-all duration-300" />
                                                     </div>
                                                   </button>
                                                 </div>
@@ -6750,9 +6746,7 @@ export const PremiumContentStrategy: React.FC<PremiumContentStrategyProps> = ({
                                                           <div className="font-semibold text-white text-sm group-hover:text-slate-200 transition-colors">Copy Text</div>
                                                           <div className="text-xs text-slate-400 group-hover:text-slate-300/80 transition-colors">Copy to clipboard</div>
                                                         </div>
-                                                        <svg className="w-4 h-4 text-slate-500 group-hover:text-slate-400 group-hover:translate-x-1 transition-all duration-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-                                                        </svg>
+                                                        <ChevronRight className="w-4 h-4 text-slate-500 group-hover:text-slate-400 group-hover:translate-x-1 transition-all duration-300" />
                                                       </div>
                                                     </button>
                                                   </div>
@@ -6878,9 +6872,7 @@ export const PremiumContentStrategy: React.FC<PremiumContentStrategyProps> = ({
                                                           <div className="font-semibold text-white text-sm group-hover:text-slate-200 transition-colors">Copy Text</div>
                                                           <div className="text-xs text-slate-400 group-hover:text-slate-300/80 transition-colors">Copy to clipboard</div>
                                                         </div>
-                                                        <svg className="w-4 h-4 text-slate-500 group-hover:text-slate-400 group-hover:translate-x-1 transition-all duration-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-                                                        </svg>
+                                                        <ChevronRight className="w-4 h-4 text-slate-500 group-hover:text-slate-400 group-hover:translate-x-1 transition-all duration-300" />
                                                       </div>
                                                     </button>
                                                   </div>
@@ -7006,9 +6998,7 @@ export const PremiumContentStrategy: React.FC<PremiumContentStrategyProps> = ({
                                                           <div className="font-semibold text-white text-sm group-hover:text-slate-200 transition-colors">Copy Text</div>
                                                           <div className="text-xs text-slate-400 group-hover:text-slate-300/80 transition-colors">Copy to clipboard</div>
                                                         </div>
-                                                        <svg className="w-4 h-4 text-slate-500 group-hover:text-slate-400 group-hover:translate-x-1 transition-all duration-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-                                                        </svg>
+                                                        <ChevronRight className="w-4 h-4 text-slate-500 group-hover:text-slate-400 group-hover:translate-x-1 transition-all duration-300" />
                                                       </div>
                                                     </button>
                                                   </div>
@@ -7134,9 +7124,7 @@ export const PremiumContentStrategy: React.FC<PremiumContentStrategyProps> = ({
                                                           <div className="font-semibold text-white text-sm group-hover:text-slate-200 transition-colors">Copy Text</div>
                                                           <div className="text-xs text-slate-400 group-hover:text-slate-300/80 transition-colors">Copy to clipboard</div>
                                                         </div>
-                                                        <svg className="w-4 h-4 text-slate-500 group-hover:text-slate-400 group-hover:translate-x-1 transition-all duration-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-                                                        </svg>
+                                                        <ChevronRight className="w-4 h-4 text-slate-500 group-hover:text-slate-400 group-hover:translate-x-1 transition-all duration-300" />
                                                       </div>
                                                     </button>
                                                   </div>
@@ -7380,9 +7368,7 @@ export const PremiumContentStrategy: React.FC<PremiumContentStrategyProps> = ({
                                                           <div className="font-semibold text-white text-sm group-hover:text-slate-200 transition-colors">Copy Text</div>
                                                           <div className="text-xs text-slate-400 group-hover:text-slate-300/80 transition-colors">Copy to clipboard</div>
                                                         </div>
-                                                        <svg className="w-4 h-4 text-slate-500 group-hover:text-slate-400 group-hover:translate-x-1 transition-all duration-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-                                                        </svg>
+                                                        <ChevronRight className="w-4 h-4 text-slate-500 group-hover:text-slate-400 group-hover:translate-x-1 transition-all duration-300" />
                                                       </div>
                                                     </button>
                                                   </div>
@@ -7633,9 +7619,7 @@ export const PremiumContentStrategy: React.FC<PremiumContentStrategyProps> = ({
                                                 <div className="font-semibold text-white text-sm group-hover:text-slate-200 transition-colors">Copy Text</div>
                                                 <div className="text-xs text-slate-400 group-hover:text-slate-300/80 transition-colors">Copy to clipboard</div>
                                               </div>
-                                              <svg className="w-4 h-4 text-slate-500 group-hover:text-slate-400 group-hover:translate-x-1 transition-all duration-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-                                              </svg>
+                                              <ChevronRight className="w-4 h-4 text-slate-500 group-hover:text-slate-400 group-hover:translate-x-1 transition-all duration-300" />
                                             </div>
                                           </button>
                                         </div>
@@ -7832,9 +7816,7 @@ export const PremiumContentStrategy: React.FC<PremiumContentStrategyProps> = ({
                                                 <div className="font-semibold text-white text-sm group-hover:text-slate-200 transition-colors">Copy Text</div>
                                                 <div className="text-xs text-slate-400 group-hover:text-slate-300/80 transition-colors">Copy to clipboard</div>
                                               </div>
-                                              <svg className="w-4 h-4 text-slate-500 group-hover:text-slate-400 group-hover:translate-x-1 transition-all duration-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-                                              </svg>
+                                              <ChevronRight className="w-4 h-4 text-slate-500 group-hover:text-slate-400 group-hover:translate-x-1 transition-all duration-300" />
                                             </div>
                                           </button>
                                         </div>
@@ -8230,9 +8212,7 @@ export const PremiumContentStrategy: React.FC<PremiumContentStrategyProps> = ({
                                                 <div className="font-semibold text-white text-sm group-hover:text-slate-200 transition-colors">Copy Text</div>
                                                 <div className="text-xs text-slate-400 group-hover:text-slate-300/80 transition-colors">Copy to clipboard</div>
                                               </div>
-                                              <svg className="w-4 h-4 text-slate-500 group-hover:text-slate-400 group-hover:translate-x-1 transition-all duration-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-                                              </svg>
+                                              <ChevronRight className="w-4 h-4 text-slate-500 group-hover:text-slate-400 group-hover:translate-x-1 transition-all duration-300" />
                                             </div>
                                           </button>
                                         </div>
@@ -10378,7 +10358,7 @@ export const PremiumContentStrategy: React.FC<PremiumContentStrategyProps> = ({
                     }}
                     className="px-3 py-1 bg-slate-700 hover:bg-slate-600 text-slate-300 text-xs rounded transition-colors"
                   >
-                    �������� Refresh
+                    ������� Refresh
                   </button>
                 </div>
                 <div className="overflow-x-auto">


### PR DESCRIPTION
## Purpose
The user requested two UI improvements: moving the creating element lower to prevent overlap with the X button during strategy generation, and replacing inline SVG icons with proper Lucide React components for better consistency and maintainability.

## Code changes
- **Layout fix**: Added `mt-8` margin-top class to the actions container to prevent overlap with close button during strategy generation
- **Icon standardization**: Replaced multiple inline SVG elements with Lucide React components:
  - Added imports for `ChevronRight`, `Send`, `GitBranch`, and `Clipboard` icons
  - Replaced clipboard SVG icons with `<Clipboard>` component across multiple copy buttons
  - Replaced chevron right SVG icons with `<ChevronRight>` component
  - Updated "Send as Text" button to use `<Send>` icon instead of `<FileText>`
  - Updated "Send as Mind Map" button to use `<GitBranch>` and `<Brain>` icons instead of `<Network>` and `<Sparkles>`
  - Updated help text to use icon components instead of emoji characters

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3`

🔗 [Edit in Builder.io](https://builder.io/app/projects/d3c7e7e4e99c457cbae1c064f030f909/zenith-hub)

👀 [Preview Link](https://d3c7e7e4e99c457cbae1c064f030f909-zenith-hub.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d3c7e7e4e99c457cbae1c064f030f909</projectId>-->
<!--<branchName>zenith-hub</branchName>-->