### PR TITLE
Fix history item layout and add click functionality

### DIFF
--- a/src/components/HistoryIntegration.tsx
+++ b/src/components/HistoryIntegration.tsx
@@ -26,7 +26,7 @@ const HistoryIntegration: React.FC<HistoryIntegrationProps> = ({
   const historyItems = history.map(item => ({
     id: item.id,
     title: item.title || `${item.contentType} Content`,
-    type: item.contentType === 'YoutubeChannelStats' ? 'analytics' as const : 
+    type: item.contentType === 'YoutubeChannelStats' ? 'analytics' as const :
           item.contentType === 'ChannelAnalysis' ? 'analytics' as const :
           item.contentType === 'ThumbnailMaker' ? 'image' as const :
           item.contentType === 'ContentStrategy' ? 'strategy' as const : 'text' as const,
@@ -35,8 +35,7 @@ const HistoryIntegration: React.FC<HistoryIntegrationProps> = ({
     timestamp: item.timestamp,
     tags: item.tags || [],
     starred: false,
-    views: Math.floor(Math.random() * 2000) + 100,
-    performance: Math.floor(Math.random() * 40) + 60,
+    userInput: item.userInput || item.title || '',
   }));
 
   // Rating handler function

--- a/src/components/HistoryIntegration.tsx
+++ b/src/components/HistoryIntegration.tsx
@@ -9,6 +9,7 @@ interface HistoryItem {
   platform?: string;
   timestamp: Date;
   tags?: string[];
+  userInput?: string;
 }
 
 interface HistoryIntegrationProps {

--- a/src/components/HistoryIntegration.tsx
+++ b/src/components/HistoryIntegration.tsx
@@ -106,7 +106,79 @@ const HistoryIntegration: React.FC<HistoryIntegrationProps> = ({
     <HistoryWorldClass
       historyItems={historyItems}
       onViewItem={(item) => {
-        console.log("Viewing item:", item);
+        // Find the original history item to get full input and output
+        const originalItem = history.find(h => h.id === item.id);
+        if (originalItem) {
+          // Create a detailed view of the item
+          const modal = document.createElement('div');
+          modal.innerHTML = `
+            <div style="
+              position: fixed;
+              top: 0;
+              left: 0;
+              right: 0;
+              bottom: 0;
+              background: rgba(0,0,0,0.8);
+              display: flex;
+              justify-content: center;
+              align-items: center;
+              z-index: 10000;
+              padding: 20px;
+            " onclick="this.remove()">
+              <div style="
+                background: linear-gradient(135deg, #0f172a, #1e293b);
+                border: 1px solid #334155;
+                border-radius: 12px;
+                padding: 24px;
+                max-width: 800px;
+                max-height: 80vh;
+                overflow-y: auto;
+                color: white;
+                box-shadow: 0 25px 50px rgba(0,0,0,0.5);
+              " onclick="event.stopPropagation()">
+                <div style="display: flex; justify-content: between; align-items: center; margin-bottom: 20px;">
+                  <h2 style="margin: 0; font-size: 24px; font-weight: 600; color: #38bdf8;">
+                    ${item.type === 'text' ? 'Content Idea' :
+                      item.type === 'image' ? 'Image Idea' :
+                      item.type === 'video' ? 'Video Idea' :
+                      item.type === 'analytics' ? 'Analytics' :
+                      item.type === 'strategy' ? 'Strategy' :
+                      item.type.charAt(0).toUpperCase() + item.type.slice(1)} for ${item.platform}
+                  </h2>
+                  <button onclick="this.closest('[style*=\"position: fixed\"]').remove()" style="
+                    background: none;
+                    border: none;
+                    color: #94a3b8;
+                    font-size: 24px;
+                    cursor: pointer;
+                    padding: 0;
+                    margin-left: auto;
+                  ">×</button>
+                </div>
+
+                <div style="margin-bottom: 20px;">
+                  <h3 style="margin: 0 0 8px 0; font-size: 16px; font-weight: 500; color: #60a5fa;">User Input:</h3>
+                  <p style="margin: 0; padding: 12px; background: #1e293b; border-radius: 8px; border: 1px solid #475569; line-height: 1.5;">
+                    ${originalItem.userInput || item.userInput || 'No input provided'}
+                  </p>
+                </div>
+
+                <div>
+                  <h3 style="margin: 0 0 8px 0; font-size: 16px; font-weight: 500; color: #60a5fa;">Generated Output:</h3>
+                  <div style="padding: 12px; background: #1e293b; border-radius: 8px; border: 1px solid #475569; line-height: 1.5;">
+                    ${typeof originalItem.content === 'object' ?
+                      Object.entries(originalItem.content).map(([key, value]) =>
+                        `<div style="margin-bottom: 12px;"><strong style="color: #fbbf24;">${key}:</strong><br/>${value}</div>`
+                      ).join('') :
+                      originalItem.content || item.content}
+                  </div>
+                </div>
+              </div>
+            </div>
+          `;
+
+          document.body.appendChild(modal);
+        }
       }}
       onDeleteItem={(itemId) => {
         const confirmDelete = confirm("Are you sure you want to delete this item?");

--- a/src/components/HistoryIntegration.tsx
+++ b/src/components/HistoryIntegration.tsx
@@ -7,7 +7,7 @@ interface HistoryItem {
   contentType: string;
   content: any;
   platform?: string;
-  timestamp: Date;
+  timestamp: Date | number;
   tags?: string[];
   userInput?: string;
 }

--- a/src/components/HistoryIntegration.tsx
+++ b/src/components/HistoryIntegration.tsx
@@ -106,78 +106,94 @@ const HistoryIntegration: React.FC<HistoryIntegrationProps> = ({
     <HistoryWorldClass
       historyItems={historyItems}
       onViewItem={(item) => {
+        console.log("History item clicked:", item);
+
         // Find the original history item to get full input and output
         const originalItem = history.find(h => h.id === item.id);
+        console.log("Original item found:", originalItem);
+
         if (originalItem) {
           // Create a detailed view of the item
           const modal = document.createElement('div');
-          modal.innerHTML = `
-            <div style="
-              position: fixed;
-              top: 0;
-              left: 0;
-              right: 0;
-              bottom: 0;
-              background: rgba(0,0,0,0.8);
-              display: flex;
-              justify-content: center;
-              align-items: center;
-              z-index: 10000;
-              padding: 20px;
-            " onclick="this.remove()">
-              <div style="
-                background: linear-gradient(135deg, #0f172a, #1e293b);
-                border: 1px solid #334155;
-                border-radius: 12px;
-                padding: 24px;
-                max-width: 800px;
-                max-height: 80vh;
-                overflow-y: auto;
-                color: white;
-                box-shadow: 0 25px 50px rgba(0,0,0,0.5);
-              " onclick="event.stopPropagation()">
-                <div style="display: flex; justify-content: between; align-items: center; margin-bottom: 20px;">
-                  <h2 style="margin: 0; font-size: 24px; font-weight: 600; color: #38bdf8;">
-                    ${item.type === 'text' ? 'Content Idea' :
-                      item.type === 'image' ? 'Image Idea' :
-                      item.type === 'video' ? 'Video Idea' :
-                      item.type === 'analytics' ? 'Analytics' :
-                      item.type === 'strategy' ? 'Strategy' :
-                      item.type.charAt(0).toUpperCase() + item.type.slice(1)} for ${item.platform}
-                  </h2>
-                  <button onclick="this.closest('[style*=\"position: fixed\"]').remove()" style="
-                    background: none;
-                    border: none;
-                    color: #94a3b8;
-                    font-size: 24px;
-                    cursor: pointer;
-                    padding: 0;
-                    margin-left: auto;
-                  ">×</button>
-                </div>
+          modal.style.cssText = `
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background: rgba(0,0,0,0.8);
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            z-index: 10000;
+            padding: 20px;
+          `;
 
-                <div style="margin-bottom: 20px;">
-                  <h3 style="margin: 0 0 8px 0; font-size: 16px; font-weight: 500; color: #60a5fa;">User Input:</h3>
-                  <p style="margin: 0; padding: 12px; background: #1e293b; border-radius: 8px; border: 1px solid #475569; line-height: 1.5;">
-                    ${originalItem.userInput || item.userInput || 'No input provided'}
-                  </p>
-                </div>
+          modal.onclick = () => modal.remove();
 
-                <div>
-                  <h3 style="margin: 0 0 8px 0; font-size: 16px; font-weight: 500; color: #60a5fa;">Generated Output:</h3>
-                  <div style="padding: 12px; background: #1e293b; border-radius: 8px; border: 1px solid #475569; line-height: 1.5;">
-                    ${typeof originalItem.content === 'object' ?
-                      Object.entries(originalItem.content).map(([key, value]) =>
-                        `<div style="margin-bottom: 12px;"><strong style="color: #fbbf24;">${key}:</strong><br/>${value}</div>`
-                      ).join('') :
-                      originalItem.content || item.content}
-                  </div>
-                </div>
+          const content = document.createElement('div');
+          content.style.cssText = `
+            background: linear-gradient(135deg, #0f172a, #1e293b);
+            border: 1px solid #334155;
+            border-radius: 12px;
+            padding: 24px;
+            max-width: 800px;
+            max-height: 80vh;
+            overflow-y: auto;
+            color: white;
+            box-shadow: 0 25px 50px rgba(0,0,0,0.5);
+          `;
+
+          content.onclick = (e) => e.stopPropagation();
+
+          const contentType = item.type === 'text' ? 'Content Idea' :
+                             item.type === 'image' ? 'Image Idea' :
+                             item.type === 'video' ? 'Video Idea' :
+                             item.type === 'analytics' ? 'Analytics' :
+                             item.type === 'strategy' ? 'Strategy' :
+                             item.type.charAt(0).toUpperCase() + item.type.slice(1);
+
+          content.innerHTML = `
+            <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 20px;">
+              <h2 style="margin: 0; font-size: 24px; font-weight: 600; color: #38bdf8;">
+                ${contentType} for ${item.platform}
+              </h2>
+              <button id="close-modal" style="
+                background: none;
+                border: none;
+                color: #94a3b8;
+                font-size: 24px;
+                cursor: pointer;
+                padding: 0;
+                margin-left: auto;
+              ">×</button>
+            </div>
+
+            <div style="margin-bottom: 20px;">
+              <h3 style="margin: 0 0 8px 0; font-size: 16px; font-weight: 500; color: #60a5fa;">User Input:</h3>
+              <p style="margin: 0; padding: 12px; background: #1e293b; border-radius: 8px; border: 1px solid #475569; line-height: 1.5;">
+                ${originalItem.userInput || item.userInput || 'No input provided'}
+              </p>
+            </div>
+
+            <div>
+              <h3 style="margin: 0 0 8px 0; font-size: 16px; font-weight: 500; color: #60a5fa;">Generated Output:</h3>
+              <div style="padding: 12px; background: #1e293b; border-radius: 8px; border: 1px solid #475569; line-height: 1.5;">
+                ${typeof originalItem.content === 'object' ?
+                  JSON.stringify(originalItem.content, null, 2) :
+                  originalItem.content || item.content}
               </div>
             </div>
           `;
 
+          modal.appendChild(content);
           document.body.appendChild(modal);
+
+          // Add close button event listener
+          const closeBtn = content.querySelector('#close-modal');
+          if (closeBtn) {
+            closeBtn.addEventListener('click', () => modal.remove());
+          }
         }
       }}
       onDeleteItem={(itemId) => {

--- a/src/components/HistoryWorldClass.tsx
+++ b/src/components/HistoryWorldClass.tsx
@@ -891,24 +891,6 @@ const HistoryWorldClass: React.FC<HistoryWorldClassProps> = ({
                   </div>
                 )}
 
-                {/* Performance Metrics */}
-                {(item.analyticsData?.performance || item.performance) && (
-                  <div className="mb-4">
-                    <div className="flex justify-between items-center mb-1">
-                      <span className="text-xs text-[var(--text-tertiary)]">Performance</span>
-                      <span className="text-xs font-medium text-[var(--text-primary)]">{item.analyticsData?.performance || item.performance}%</span>
-                    </div>
-                    <ProgressBar
-                      value={item.analyticsData?.performance || item.performance || 0}
-                      size="sm"
-                      color={
-                        (item.analyticsData?.performance || item.performance || 0) >= 80 ? "var(--color-success)" :
-                        (item.analyticsData?.performance || item.performance || 0) >= 60 ? "var(--color-warning)" :
-                        "var(--color-error)"
-                      }
-                    />
-                  </div>
-                )}
 
                 {/* Action Buttons */}
                 <div className="flex items-center justify-between mb-4">

--- a/src/components/HistoryWorldClass.tsx
+++ b/src/components/HistoryWorldClass.tsx
@@ -827,19 +827,29 @@ const HistoryWorldClass: React.FC<HistoryWorldClassProps> = ({
               </div>
 
               {/* Star Button */}
-              <button
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onStarItem?.(item.id);
-                }}
-                className={`absolute top-4 right-4 z-10 p-1 rounded-lg transition-colors ${
-                  item.starred 
-                    ? "text-yellow-400 bg-yellow-400/20" 
-                    : "text-[var(--text-tertiary)] hover:text-yellow-400 hover:bg-yellow-400/20"
-                }`}
-              >
-                <Star className="w-4 h-4" fill={item.starred ? "currentColor" : "none"} />
-              </button>
+              <div className="absolute top-4 right-4 z-10 flex items-center space-x-2">
+                <span className="text-xs text-[var(--text-tertiary)] bg-[var(--surface-tertiary)] px-2 py-1 rounded-md">
+                  Generator • {item.type === 'text' ? 'Content Idea' :
+                             item.type === 'image' ? 'Image Idea' :
+                             item.type === 'video' ? 'Video Idea' :
+                             item.type === 'analytics' ? 'Analytics' :
+                             item.type === 'strategy' ? 'Strategy' :
+                             item.type.charAt(0).toUpperCase() + item.type.slice(1)} • {item.platform}
+                </span>
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onStarItem?.(item.id);
+                  }}
+                  className={`p-1 rounded-lg transition-colors ${
+                    item.starred
+                      ? "text-yellow-400 bg-yellow-400/20"
+                      : "text-[var(--text-tertiary)] hover:text-yellow-400 hover:bg-yellow-400/20"
+                  }`}
+                >
+                  <Star className="w-4 h-4" fill={item.starred ? "currentColor" : "none"} />
+                </button>
+              </div>
 
               <div className="pt-8">
                 {/* Type Icon and Platform */}

--- a/src/components/HistoryWorldClass.tsx
+++ b/src/components/HistoryWorldClass.tsx
@@ -863,7 +863,12 @@ const HistoryWorldClass: React.FC<HistoryWorldClassProps> = ({
                   }}
                   title="Click to view generated content"
                 >
-                  {item.type.charAt(0).toUpperCase() + item.type.slice(1)} for {item.platform}: {item.userInput || item.title}
+                  {item.type === 'text' ? 'Content Idea' :
+                   item.type === 'image' ? 'Image Idea' :
+                   item.type === 'video' ? 'Video Idea' :
+                   item.type === 'analytics' ? 'Analytics' :
+                   item.type === 'strategy' ? 'Strategy' :
+                   item.type.charAt(0).toUpperCase() + item.type.slice(1)} for {item.platform}
                 </h3>
                 <p className="body-sm mb-4 line-clamp-3">{item.content}</p>
 

--- a/src/components/HistoryWorldClass.tsx
+++ b/src/components/HistoryWorldClass.tsx
@@ -86,7 +86,7 @@ interface HistoryItem {
   type: 'text' | 'image' | 'video' | 'analytics' | 'strategy';
   content: string;
   platform: string;
-  timestamp: Date;
+  timestamp: Date | number;
   tags: string[];
   starred: boolean;
   views?: number;

--- a/src/components/HistoryWorldClass.tsx
+++ b/src/components/HistoryWorldClass.tsx
@@ -409,15 +409,16 @@ const HistoryWorldClass: React.FC<HistoryWorldClassProps> = ({
     }
   };
 
-  const formatTimeAgo = (date: Date) => {
+  const formatTimeAgo = (date: Date | number) => {
     const now = new Date();
-    const diffInSeconds = Math.floor((now.getTime() - date.getTime()) / 1000);
-    
+    const targetDate = typeof date === 'number' ? new Date(date) : date;
+    const diffInSeconds = Math.floor((now.getTime() - targetDate.getTime()) / 1000);
+
     if (diffInSeconds < 60) return "Just now";
     if (diffInSeconds < 3600) return `${Math.floor(diffInSeconds / 60)}m ago`;
     if (diffInSeconds < 86400) return `${Math.floor(diffInSeconds / 3600)}h ago`;
     if (diffInSeconds < 604800) return `${Math.floor(diffInSeconds / 86400)}d ago`;
-    return date.toLocaleDateString();
+    return targetDate.toLocaleDateString();
   };
 
   const toggleItemSelection = (itemId: string) => {

--- a/src/components/HistoryWorldClass.tsx
+++ b/src/components/HistoryWorldClass.tsx
@@ -970,12 +970,6 @@ const HistoryWorldClass: React.FC<HistoryWorldClassProps> = ({
                       <Clock className="w-3 h-3" />
                       <span>{formatTimeAgo(item.timestamp)}</span>
                     </span>
-                    {(item.analyticsData?.views || item.views) && (
-                      <span className="flex items-center space-x-1">
-                        <Eye className="w-3 h-3" />
-                        <span>{item.analyticsData?.views || item.views}</span>
-                      </span>
-                    )}
                     {item.sentToCanvas && (
                       <span className="flex items-center space-x-1 text-[var(--brand-primary)]">
                         <Send className="w-3 h-3" />

--- a/src/components/HistoryWorldClass.tsx
+++ b/src/components/HistoryWorldClass.tsx
@@ -855,7 +855,14 @@ const HistoryWorldClass: React.FC<HistoryWorldClassProps> = ({
                 </div>
 
                 {/* Title and Content */}
-                <h3 className="heading-4 mb-2 line-clamp-2">
+                <h3
+                  className="heading-4 mb-2 line-clamp-2 cursor-pointer hover:text-[var(--brand-primary)] transition-colors"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onViewItem?.(item);
+                  }}
+                  title="Click to view generated content"
+                >
                   {item.type.charAt(0).toUpperCase() + item.type.slice(1)} for {item.platform}: {item.userInput || item.title}
                 </h3>
                 <p className="body-sm mb-4 line-clamp-3">{item.content}</p>

--- a/src/components/HistoryWorldClass.tsx
+++ b/src/components/HistoryWorldClass.tsx
@@ -828,8 +828,8 @@ const HistoryWorldClass: React.FC<HistoryWorldClassProps> = ({
               </div>
 
               {/* Star Button */}
-              <div className="absolute top-4 right-4 z-10 flex items-center space-x-2">
-                <span className="text-xs text-[var(--text-tertiary)] bg-[var(--surface-tertiary)] px-2 py-1 rounded-md">
+              <div className="absolute top-3 right-3 z-10 flex items-center gap-2">
+                <span className="text-xs text-[var(--text-tertiary)] bg-[var(--surface-tertiary)] px-2 py-1 rounded-md whitespace-nowrap">
                   Generator • {item.type === 'text' ? 'Content Idea' :
                              item.type === 'image' ? 'Image Idea' :
                              item.type === 'video' ? 'Video Idea' :
@@ -842,7 +842,7 @@ const HistoryWorldClass: React.FC<HistoryWorldClassProps> = ({
                     e.stopPropagation();
                     onStarItem?.(item.id);
                   }}
-                  className={`p-1 rounded-lg transition-colors ${
+                  className={`p-1.5 rounded-lg transition-colors ${
                     item.starred
                       ? "text-yellow-400 bg-yellow-400/20"
                       : "text-[var(--text-tertiary)] hover:text-yellow-400 hover:bg-yellow-400/20"

--- a/src/components/HistoryWorldClass.tsx
+++ b/src/components/HistoryWorldClass.tsx
@@ -855,7 +855,9 @@ const HistoryWorldClass: React.FC<HistoryWorldClassProps> = ({
                 </div>
 
                 {/* Title and Content */}
-                <h3 className="heading-4 mb-2 line-clamp-2">{item.title}</h3>
+                <h3 className="heading-4 mb-2 line-clamp-2">
+                  {item.type.charAt(0).toUpperCase() + item.type.slice(1)} for {item.platform}: {item.userInput || item.title}
+                </h3>
                 <p className="body-sm mb-4 line-clamp-3">{item.content}</p>
 
                 {/* Tags */}

--- a/src/components/HistoryWorldClass.tsx
+++ b/src/components/HistoryWorldClass.tsx
@@ -93,6 +93,7 @@ interface HistoryItem {
   performance?: number;
   thumbnail?: string;
   rating?: 1 | -1 | 0;
+  userInput?: string;
 }
 
 interface HistoryWorldClassProps {

--- a/src/components/HistoryWorldClass.tsx
+++ b/src/components/HistoryWorldClass.tsx
@@ -865,14 +865,7 @@ const HistoryWorldClass: React.FC<HistoryWorldClassProps> = ({
                 </div>
 
                 {/* Title and Content */}
-                <h3
-                  className="heading-4 mb-2 line-clamp-2 cursor-pointer hover:text-[var(--brand-primary)] transition-colors"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onViewItem?.(item);
-                  }}
-                  title="Click to view generated content"
-                >
+                <h3 className="heading-4 mb-2 line-clamp-2">
                   {item.type === 'text' ? 'Content Idea' :
                    item.type === 'image' ? 'Image Idea' :
                    item.type === 'video' ? 'Video Idea' :


### PR DESCRIPTION
## Purpose

The user was experiencing multiple UI/UX issues with the history component:
- Timestamp and "ago" text were stacked vertically instead of being inline
- Generator type labels (Generator • Content Idea • YouTube) were missing from the display
- Clicking on history items had no functionality - nothing happened when clicked
- The user wanted the type labels positioned next to the star icon in the top row

## Code changes

**Layout and Display Fixes:**
- Moved Generator type labels to the top-right area next to the star icon
- Updated title display to show content type (Content Idea, Image Idea, etc.) with platform
- Fixed timestamp formatting to handle both Date objects and numbers
- Removed performance metrics and views display that were cluttering the layout

**Click Functionality:**
- Implemented modal popup when clicking history items
- Modal displays both user input and generated output in a clean, readable format
- Added proper event handling with click-to-close functionality
- Enhanced styling with gradient backgrounds and proper spacing

**Data Structure Updates:**
- Added `userInput` field to HistoryItem interface
- Updated timestamp type to support both Date and number formats
- Removed unused performance and views properties from item mapping

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 19`

🔗 [Edit in Builder.io](https://builder.io/app/projects/d7ca403d925045b68769a889e74d92bf/spark-field)

👀 [Preview Link](https://d7ca403d925045b68769a889e74d92bf-spark-field.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d7ca403d925045b68769a889e74d92bf</projectId>-->
<!--<branchName>spark-field</branchName>-->